### PR TITLE
Fix install with Poetry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='django-simple-rbac',


### PR DESCRIPTION
`distutils` does not support `install_requires`, which makes Poetry crash. We have to use `setuptools` instead.