### PR TITLE
Hotfix/optims

### DIFF
--- a/django_simple_rbac/helpers.py
+++ b/django_simple_rbac/helpers.py
@@ -22,13 +22,14 @@ def is_allowed(request, operation, resource, authorities=None):
     # apply filters on authority list
     filter_authorities.send(sender=None, authorities=authorities, request=request, operation=operation, resource=resource)
 
+    # the request is wrapped and become the special '__current__' role
+    current_role = CurrentRoleAdapter(request)
+
     # check permissions on each authority
     for authority in authorities:
         registry, direct_allow, direct_deny = _get_acl_registry(authority, request)
         if registry:
             try:
-                # the request is wrapped and become the special '__current__' role
-                current_role = CurrentRoleAdapter(request)
                 if registry.is_allowed(current_role, operation, resource):
                     if direct_allow:
                         return Permission(True, authority.acl_registry_name)

--- a/django_simple_rbac/registry.py
+++ b/django_simple_rbac/registry.py
@@ -2,7 +2,7 @@ import copy
 import rbac.acl
 import yaml
 from django.conf import settings
-
+from django.utils.functional import cached_property
 
 STRATEGY_FILTER = 'filter'
 STRATEGY_DIRECT_DENY = 'deny'
@@ -105,8 +105,13 @@ class Adapter(object):
     def __init__(self, adaptee):
         self.adaptee = adaptee
 
-    def __hash__(self):
+    @cached_property
+    def _hash(self):
+        """We want to cache the hash because it won't change over time."""
         return hash(str(self))
+
+    def __hash__(self):
+        return self._hash
 
     def __eq__(self, other):
         return str(other) == str(self)
@@ -114,8 +119,13 @@ class Adapter(object):
 
 class ResourceAdapter(Adapter):
 
-    def __str__(self):
+    @cached_property
+    def _str(self):
+        """We want to cache this because it won't change over time."""
         return self.adaptee if isinstance(self.adaptee, basestring) else self.adaptee.acl_resource_name
+
+    def __str__(self):
+        return self._str
 
     @property
     def acl_authorities(self):


### PR DESCRIPTION
Adds a permission cache on `request` object : during a request, if we test exactly the same operation/resource pair several times, it will grab the permission from the cache instead of computing it again.

Warning : `str(resource)` has to return something meaningful or it will do weird things...
